### PR TITLE
DocForm remove obj

### DIFF
--- a/src/main/java/com/celements/docform/DocFormRequestKey.java
+++ b/src/main/java/com/celements/docform/DocFormRequestKey.java
@@ -47,8 +47,6 @@ public class DocFormRequestKey {
   }
 
   public boolean sameObject(DocFormRequestKey other) {
-    System.out.println("compare " + this);
-    System.out.println("with " + other);
     return (this.classRef != null) && (this.objNb != null) && (this.objNb >= 0)
         && ObjectUtils.equals(this.classRef, other.classRef) 
         && ObjectUtils.equals(this.objNb, other.objNb);

--- a/src/main/java/com/celements/docform/DocFormRequestKey.java
+++ b/src/main/java/com/celements/docform/DocFormRequestKey.java
@@ -1,0 +1,64 @@
+package com.celements.docform;
+
+import org.apache.commons.lang.ObjectUtils;
+import org.xwiki.model.reference.DocumentReference;
+
+public class DocFormRequestKey {
+
+  private final String keyString;
+  private final DocumentReference docRef;
+  private final DocumentReference classRef;
+  private final boolean remove;
+  private final Integer objNb;
+  private final String fieldName;
+  
+  public DocFormRequestKey(String key, DocumentReference docRef, 
+      DocumentReference classRef, boolean remove, Integer objNb, String fieldName) {
+    this.keyString = key;
+    this.docRef = docRef;
+    this.classRef = classRef;
+    this.remove = remove;
+    this.objNb = objNb;
+    this.fieldName = fieldName;
+  }
+
+  public String getKeyString() {
+    return keyString;
+  }
+
+  public DocumentReference getDocRef() {
+    return docRef;
+  }
+
+  public DocumentReference getClassRef() {
+    return classRef;
+  }
+
+  public boolean isRemove() {
+    return remove;
+  }
+
+  public Integer getObjNb() {
+    return objNb;
+  }
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  public boolean sameObject(DocFormRequestKey other) {
+    System.out.println("compare " + this);
+    System.out.println("with " + other);
+    return (this.classRef != null) && (this.objNb != null) && (this.objNb >= 0)
+        && ObjectUtils.equals(this.classRef, other.classRef) 
+        && ObjectUtils.equals(this.objNb, other.objNb);
+  }
+
+  @Override
+  public String toString() {
+    return "DocFormRequestKey [keyString=" + keyString + ", docRef=" + docRef 
+        + ", classRef=" + classRef + ", remove=" + remove + ", objNb=" + objNb 
+        + ", fieldName=" + fieldName + "]";
+  }
+
+}

--- a/src/main/java/com/celements/docform/DocFormRequestKeyParser.java
+++ b/src/main/java/com/celements/docform/DocFormRequestKeyParser.java
@@ -1,0 +1,159 @@
+package com.celements.docform;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xwiki.model.reference.DocumentReference;
+
+import com.celements.web.service.IWebUtilsService;
+import com.xpn.xwiki.web.Utils;
+
+public class DocFormRequestKeyParser {
+
+  private static Logger LOGGER = LoggerFactory.getLogger(DocFormRequestKeyParser.class);
+
+  public static final String KEY_DELIM = "_";
+  public static final String REGEX_FULLNAME = "([a-zA-Z0-9]*\\:)?[a-zA-Z0-9]*\\.[a-zA-Z0-9]*";
+  public static final String REGEX_OBJNB = "[-^]?(\\d)*";
+  public static final String REGEX_CONTENT_TITLE = "content|title";
+
+  /**
+   * Parses a given key string to {@link DocFormRequestKey} object
+   * 
+   * @param key syntax: "[fullName_]className_[-|^]objNb_fieldName" whereas fullName is 
+   * optional and objNb can be preceded by "-" to create or "^" to delete the object
+   * @param defaultDocRef used if no fullName is provided in the key
+   * @return
+   */
+  public DocFormRequestKey parse(String key, DocumentReference defaultDocRef) {
+    List<String> keyParts = new ArrayList<String>(Arrays.asList(key.split(KEY_DELIM)));
+    DocumentReference docRef = parseDocRef(keyParts, defaultDocRef);
+    DocumentReference classRef = parseClassRef(keyParts, docRef);
+    boolean remove = parseRemove(keyParts);
+    Integer objNb = parseObjNb(keyParts);
+    String fieldName = parseFieldName(keyParts);
+    DocFormRequestKey ret = new DocFormRequestKey(key, docRef, classRef, remove, objNb, 
+        fieldName);
+    if (validate(ret)) {
+      return ret;
+    } else {
+      throw new IllegalArgumentException("Illegal request key '" + ret  + "'");
+    }
+  }
+
+  private boolean validate(DocFormRequestKey key) {
+    boolean valid = (key.getDocRef() != null);
+    if (!key.getFieldName().matches(REGEX_CONTENT_TITLE)) {
+      valid &= (key.getClassRef() != null);
+      valid &= (key.getObjNb() != null);
+      if (!key.isRemove()) {
+        valid &= StringUtils.isNotBlank(key.getFieldName());
+      }
+    }
+    return valid;
+  }
+
+  private DocumentReference parseDocRef(List<String> keyParts,
+      DocumentReference defaultDocRef) {
+    DocumentReference ret = defaultDocRef;
+    if (keyParts.size() > 1 && keyParts.get(0).matches(REGEX_FULLNAME) 
+        && (keyParts.get(1).matches(REGEX_FULLNAME) 
+        || keyParts.get(1).matches(REGEX_CONTENT_TITLE))) {
+      ret = getWebUtils().resolveDocumentReference(keyParts.remove(0));
+    }
+    return ret;
+  }
+
+  private DocumentReference parseClassRef(List<String> keyParts, 
+      DocumentReference docRef) {
+    DocumentReference ret = null;
+    if (getFirst(keyParts).matches(REGEX_FULLNAME)) {
+      ret = getWebUtils().resolveDocumentReference(keyParts.remove(0), 
+          getWebUtils().getWikiRef(docRef));
+    }
+    return ret;
+  }
+
+  private boolean parseRemove(List<String> keyParts) {
+    boolean ret = false;
+    String str = getFirst(keyParts);
+    if (str.matches(REGEX_OBJNB) && str.startsWith("^")) {
+      keyParts.set(0, str.substring(1, str.length()));
+      ret = true;
+    }
+    return ret;
+  }
+
+  private Integer parseObjNb(List<String> keyParts) {
+    Integer ret = null;
+    if (getFirst(keyParts).matches(REGEX_OBJNB)) {
+      String intStr = keyParts.remove(0);
+      try {
+        ret = Integer.parseInt(intStr);
+      } catch (NumberFormatException exc) {
+        LOGGER.trace("Unable to parse: " + intStr, exc);
+      }
+    }
+    return ret;
+  }
+
+  private String parseFieldName(List<String> keyParts) {
+    return StringUtils.join(keyParts.iterator(), KEY_DELIM);
+  }
+
+  private String getFirst(List<String> list) {
+    if (list.size() > 0) {
+      return list.get(0);
+    }
+    return "";
+  }
+
+  /**
+   * Parses given key strings to {@link DocFormRequestKey} objects. 
+   * See {@link #parse(String, DocumentReference)}
+   * @param keys
+   * @param defaultDocRef
+   * @return
+   */
+  public Collection<DocFormRequestKey> parse(Collection<String> keys, 
+      DocumentReference defaultDocRef) {
+    Collection<DocFormRequestKey> ret = new ArrayList<DocFormRequestKey>();
+    for (String keyString : keys) {
+      if (StringUtils.isNotBlank(keyString)) {
+        DocFormRequestKey key = parse(keyString, defaultDocRef);
+        if (filterRequestKeySetForRemove(ret, key)) {
+          ret.add(key);
+        }
+      }
+    }
+    return ret;
+  }
+
+  private boolean filterRequestKeySetForRemove(Collection<DocFormRequestKey> keys, 
+      DocFormRequestKey key) {
+    boolean ret = true;
+    Iterator<DocFormRequestKey> iter = keys.iterator();
+    while (iter.hasNext()) {
+      DocFormRequestKey currKey = iter.next();
+      if (key.sameObject(currKey)) {
+        if (key.isRemove()) {
+          iter.remove();
+        } else if (currKey.isRemove()) {
+          ret = false;
+        }
+      }
+    }
+    return ret;
+  }
+
+  private IWebUtilsService getWebUtils() {
+    return Utils.getComponent(IWebUtilsService.class);
+  }
+
+}

--- a/src/main/java/com/celements/web/plugin/cmd/DocFormCommand.java
+++ b/src/main/java/com/celements/web/plugin/cmd/DocFormCommand.java
@@ -29,11 +29,13 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.oro.text.perl.MalformedPerl5PatternException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xwiki.model.reference.DocumentReference;
 
+import com.celements.docform.DocFormRequestKey;
+import com.celements.docform.DocFormRequestKeyParser;
 import com.celements.web.service.IWebUtilsService;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -56,17 +58,14 @@ import com.xpn.xwiki.web.XWikiRequest;
  */
 public class DocFormCommand {
 
-  private static Log LOGGER = LogFactory.getFactory().getInstance(
-      DocFormCommand.class);
+  private static Logger LOGGER = LoggerFactory.getLogger(DocFormCommand.class);
+  
   private final Map<String, BaseObject> changedObjects = new HashMap<String, BaseObject>();
   private final Map<String, XWikiDocument> changedDocs = new HashMap<String, XWikiDocument>();
 
   public Set<XWikiDocument> updateDocFromMap(String fullname, Map<String, String[]> data,
       XWikiContext context) throws XWikiException {
-    String docSpace = fullname.split("\\.")[0];
-    String docName = fullname.split("\\.")[1];
-    DocumentReference docRef = new DocumentReference(context.getDatabase(), docSpace,
-        docName);
+    DocumentReference docRef = getWebUtilsService().resolveDocumentReference(fullname);
     XWikiDocument doc = context.getWiki().getDocument(docRef, context);
     String template = context.getRequest().getParameter("template");
     if(doc.isNew() && !"".equals(template.trim())) {
@@ -80,91 +79,23 @@ public class DocFormCommand {
         LOGGER.error("Exception reading doc " + docRef + " from template " + templRef, e);
       }
     }
-    for (String key : data.keySet()) {
-      if(key != null) {
-        String[] parts = getDocFullname(key, docSpace, docName);
-        DocumentReference saveDocRef = new DocumentReference(context.getDatabase(
-            ), parts[0], parts[1]);
-        LOGGER.debug("request key:'" + key + "'=value:" + data.get(key).length);
-        if(key.matches("([a-zA-Z0-9]*\\.[a-zA-Z0-9]*_)?content")) {
-          XWikiDocument tdoc = getTranslatedDoc(saveDocRef, context);
-          tdoc.setContent(collapse(data.get(key)));
-        } else if(key.matches("([a-zA-Z0-9]*\\.[a-zA-Z0-9]*_)?title")) {
-          XWikiDocument tdoc = getTranslatedDoc(saveDocRef, context);
-          tdoc.setTitle(collapse(data.get(key)));
-        } else if(key.matches(getFindObjectFieldInRequestRegex())) {
-          XWikiDocument saveDoc = getUpdateDoc(saveDocRef, context);
-          setObjValue(saveDoc, parts[2], data.get(key), context);
-        }
+    DocFormRequestKeyParser parser = new DocFormRequestKeyParser();
+    for (DocFormRequestKey key : parser.parse(data.keySet(), docRef)) {
+      LOGGER.debug("request key:'" + key.getKeyString() + "'=value:" + data.get(
+          key.getKeyString()).length);
+      String value = collapse(data.get(key.getKeyString()));
+      if (key.getFieldName().equals("content")) {
+        XWikiDocument tSaveDoc = getTranslatedDoc(key.getDocRef(), context);
+        tSaveDoc.setContent(value);
+      } else if(key.getFieldName().equals("title")) {
+        XWikiDocument tSaveDoc = getTranslatedDoc(key.getDocRef(), context);
+        tSaveDoc.setTitle(value);
+      } else {
+        XWikiDocument saveDoc = getUpdateDoc(key.getDocRef(), context);
+        setOrRemoveObj(saveDoc, key, value, context);
       }
     }
-    HashSet<XWikiDocument> docSet = new HashSet<XWikiDocument>();
-    docSet.addAll(changedDocs.values());
-    return docSet;
-  }
-
-  String getFindObjectFieldInRequestRegex() {
-    return "([a-zA-Z0-9]*\\.[a-zA-Z0-9]*_){1,2}-?(\\d)*_(.*)";
-  }
-
-  String[] getDocFullname(String key, String defaultSpace, String defaultName) {
-    String docName = defaultName;
-    String docSpace = defaultSpace;
-    String fieldName = key;
-    if(key.matches("([a-zA-Z0-9]*\\.[a-zA-Z0-9]*_){1}(content|title)") ||
-        key.matches(getRequestParamIncludesDocNameRegex())) {
-      String docFullName = key.split("_")[0];
-      docSpace = docFullName.split("\\.")[0];
-      docName = docFullName.split("\\.")[1];
-      fieldName = key.substring(docFullName.length() + 1);
-    }
-    return new String[]{ docSpace, docName, fieldName };
-  }
-
-  String getRequestParamIncludesDocNameRegex() {
-    return "([a-zA-Z0-9]*\\.[a-zA-Z0-9]*_){2}-?(\\d)*_(.*)";
-  }
-
-  XWikiDocument setObjValue(XWikiDocument doc, String key,
-      String[] value, XWikiContext context) throws XWikiException {
-    String className = key.substring(0, key.indexOf("_"));
-    DocumentReference classRef = getWebUtilsService().resolveDocumentReference(className);
-    LOGGER.debug("key complete: " + key);
-    key = key.substring(key.indexOf("_") + 1);
-    Integer objNr = Integer.parseInt(key.substring(0, key.indexOf("_")));
-    LOGGER.debug("key -1 part: " + key);
-    key = key.substring(key.indexOf("_") + 1);
-    LOGGER.debug("key -2 parts: " + key);
-    BaseObject obj = null;
-    if(changedObjects.containsKey(getObjCacheMapKey(doc, className, objNr))) {
-      obj = changedObjects.get(getObjCacheMapKey(doc, className, objNr));
-    } else {
-      obj = doc.getXObject(classRef, objNr);
-      if((obj == null) || (objNr < 0)) {
-        obj = doc.newXObject(classRef, context);
-        LOGGER.debug("newObject for classname [" + className + "] on doc [" + doc
-            + "] <-> [" + obj.getNumber() + "] <-> [" + objNr + "].");
-      }
-      changedObjects.put(getObjCacheMapKey(doc, className, objNr), obj);
-      LOGGER.debug("got object for classname [" + className + "] on doc [" + doc
-          + "] <-> [" + obj.getNumber() + "] <-> [" + objNr + "].");
-    }
-    obj.set(key, collapse(value), context);
-    return doc;
-  }
-
-  private String getObjCacheMapKey(XWikiDocument doc, String className,
-      Integer objNr) {
-    DocumentReference docRef = doc.getDocumentReference();
-    return docRef.getLastSpaceReference().getName() + "." + docRef.getName() + "_"
-    + className + "_" + objNr;
-  }
-
-  String collapse(String[] value) {
-    List<String> valueList = new ArrayList<String>(Arrays.asList(value));
-    valueList.removeAll(Arrays.asList((String)null));
-    valueList.removeAll(Arrays.asList(""));
-    return StringUtils.join(valueList.toArray(), "|");
+    return new HashSet<XWikiDocument>(changedDocs.values());
   }
 
   XWikiDocument getUpdateDoc(DocumentReference docRef, XWikiContext context
@@ -173,15 +104,15 @@ public class DocFormCommand {
     if (doc.isNew() && "".equals(doc.getDefaultLanguage())) {
       doc.setDefaultLanguage(context.getLanguage());
     }
-    if(!changedDocs.containsKey(getFullNameForRef(docRef) + ";" + doc.getDefaultLanguage()
+    if(!changedDocs.containsKey(serialize(docRef) + ";" + doc.getDefaultLanguage()
         )) {
-      LOGGER.debug("getUpdateDoc: [" + getFullNameForRef(docRef) + ";"
+      LOGGER.debug("getUpdateDoc: [" + serialize(docRef) + ";"
           + doc.getDefaultLanguage() + "] with doc language [" + doc.getLanguage()
           + "].");
       applyCreationDateFix(doc, context);
-      changedDocs.put(getFullNameForRef(docRef) + ";" + doc.getDefaultLanguage(), doc);
+      changedDocs.put(serialize(docRef) + ";" + doc.getDefaultLanguage(), doc);
     } else {
-      doc = changedDocs.get(getFullNameForRef(docRef) + ";" + doc.getDefaultLanguage());
+      doc = changedDocs.get(serialize(docRef) + ";" + doc.getDefaultLanguage());
     }
     return doc;
   }
@@ -189,15 +120,46 @@ public class DocFormCommand {
   XWikiDocument getTranslatedDoc(DocumentReference docRef, XWikiContext context
       ) throws XWikiException {
     XWikiDocument tdoc;
-    if(!changedDocs.containsKey(getFullNameForRef(docRef) + ";" + context.getLanguage())
+    if(!changedDocs.containsKey(serialize(docRef) + ";" + context.getLanguage())
         ) {
       XWikiDocument doc = getUpdateDoc(docRef, context);
       tdoc = new AddTranslationCommand().getTranslatedDoc(doc, context.getLanguage());
-      changedDocs.put(getFullNameForRef(docRef) + ";" + context.getLanguage(), tdoc);
+      changedDocs.put(serialize(docRef) + ";" + context.getLanguage(), tdoc);
     } else {
-      tdoc = changedDocs.get(getFullNameForRef(docRef) + ";" + context.getLanguage());
+      tdoc = changedDocs.get(serialize(docRef) + ";" + context.getLanguage());
     }
     return tdoc;
+  }
+
+  XWikiDocument setOrRemoveObj(XWikiDocument doc, DocFormRequestKey key, String value, 
+      XWikiContext context) throws XWikiException {
+    BaseObject obj = changedObjects.get(getObjCacheKey(key));
+    if(obj == null) {
+      obj = doc.getXObject(key.getClassRef(), key.getObjNb());
+      if((obj == null) && (key.getObjNb() < 0)) {
+        obj = doc.newXObject(key.getClassRef(), context);
+        LOGGER.debug("setOrRemoveObj: new obj for key '{}'", key);
+      }
+      changedObjects.put(getObjCacheKey(key), obj);
+      LOGGER.debug("setOrRemoveObj: got obj for key '{}'", key);
+    }
+    if (obj != null) {
+      if (key.isRemove()) {
+        boolean success = doc.removeXObject(obj);
+        LOGGER.debug("setOrRemoveObj: removing obj for key '{}' was success '{}'", key, 
+            success);
+      } else {
+        obj.set(key.getFieldName(), value, context);
+        LOGGER.debug("setOrRemoveObj: set value '{}' for key '{}'", value, key);
+      }
+    }
+    return doc;
+  }
+
+  private String getObjCacheKey(DocFormRequestKey key) {
+    return serialize(key.getDocRef()) + DocFormRequestKeyParser.KEY_DELIM 
+        + serialize(key.getClassRef()) + DocFormRequestKeyParser.KEY_DELIM 
+        + key.getObjNb();
   }
 
   void applyCreationDateFix(XWikiDocument doc, XWikiContext context) {
@@ -207,10 +169,6 @@ public class DocFormCommand {
       doc.setCreationDate(new Date());
       doc.setCreator(context.getUser());
     }
-  }
-
-  private String getFullNameForRef(DocumentReference docRef) {
-    return docRef.getLastSpaceReference().getName() + "." + docRef.getName();
   }
 
   /**
@@ -241,15 +199,23 @@ public class DocFormCommand {
     if(param.matches(getFindObjectFieldInRequestRegex())){
       int pos = 0;
       if(param.matches(getRequestParamIncludesDocNameRegex())) { pos = 1; }
-      String[] paramSplit = param.split("_");
+      String[] paramSplit = param.split(DocFormRequestKeyParser.KEY_DELIM);
       String className = paramSplit[pos];
       String fieldName = paramSplit[pos+2];
       for(int i = pos+3; i < paramSplit.length; i++) {
-        fieldName += "_" + paramSplit[i];
+        fieldName += DocFormRequestKeyParser.KEY_DELIM + paramSplit[i];
       }
       return validateField(className, fieldName, value, context);
     }
     return null;
+  }
+  
+  String getFindObjectFieldInRequestRegex() {
+    return "([a-zA-Z0-9]*\\.[a-zA-Z0-9]*_){1,2}[-^]?(\\d)*_(.*)";
+  }
+  
+  private String getRequestParamIncludesDocNameRegex() {
+    return "([a-zA-Z0-9]*\\.[a-zA-Z0-9]*_){2}[-^]?(\\d)*_(.*)";
   }
 
   /**
@@ -304,6 +270,17 @@ public class DocFormCommand {
       LOGGER.error("Cannot get document class [" + className + "].", exp);
     }
     return bclass;
+  }
+
+  String collapse(String[] value) {
+    List<String> valueList = new ArrayList<String>(Arrays.asList(value));
+    valueList.removeAll(Arrays.asList((String)null));
+    valueList.removeAll(Arrays.asList(""));
+    return StringUtils.join(valueList.toArray(), "|");
+  }
+
+  private String serialize(DocumentReference docRef) {
+    return getWebUtilsService().getRefDefaultSerializer().serialize(docRef);
   }
 
   Map<String, BaseObject> getChangedObjects() {

--- a/src/test/java/com/celements/docform/DocFormRequestKeyParserTest.java
+++ b/src/test/java/com/celements/docform/DocFormRequestKeyParserTest.java
@@ -1,0 +1,278 @@
+package com.celements.docform;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.WikiReference;
+
+import com.celements.common.test.AbstractBridgedComponentTestCase;
+import com.celements.web.service.IWebUtilsService;
+import com.xpn.xwiki.web.Utils;
+
+public class DocFormRequestKeyParserTest extends AbstractBridgedComponentTestCase {
+
+  private DocFormRequestKeyParser parser;
+
+  @Before
+  public void setUp_DocFormRequestKeyParserTest() throws Exception {
+    parser = new DocFormRequestKeyParser();
+  }
+
+  @Test
+  public void testParse_blank() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    String keyString = "";
+    try {
+      parser.parse(keyString, docRef);
+      fail("expecting IllegalArgumentException, blank key is not valid");
+    } catch (IllegalArgumentException iae) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testParse_keyword_content() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    String fieldName = "content";
+    String keyString = serialize(docRef, false) + "_" + fieldName;
+    DocFormRequestKey key = parser.parse(keyString, null);
+    assertKey(key, keyString, docRef, null, false, null, fieldName);
+  }
+
+  @Test
+  public void testParse_keyword_title() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    String fieldName = "title";
+    String keyString = serialize(docRef, false) + "_" + fieldName;
+    DocFormRequestKey key = parser.parse(keyString, null);
+    assertKey(key, keyString, docRef, null, false, null, fieldName);
+  }
+
+  @Test
+  public void testParse_keyword_noFullName() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    String keyString = "content";
+    DocFormRequestKey key = parser.parse(keyString, docRef);
+    assertKey(key, keyString, docRef, null, false, null, keyString);
+  }
+
+  @Test
+  public void testParse_keyword_other() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    String fieldName = "asdf";
+    String keyString = serialize(docRef, false) + "_" + fieldName;
+    try {
+      parser.parse(keyString, null);
+      fail("expecting IllegalArgumentException, 'asdf' is not valid keyword");
+    } catch (IllegalArgumentException iae) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testParse_obj() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    Integer objNb = 3;
+    String fieldName = "asdf";
+    String keyString = serialize(docRef, false) + "_" + serialize(classRef, false) + "_" 
+        + objNb + "_" + fieldName;
+    DocFormRequestKey key = parser.parse(keyString, null);
+    assertKey(key, keyString, docRef, classRef, false, objNb, fieldName);
+  }
+
+  @Test
+  public void testParse_obj_noFullName() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    Integer objNb = 3;
+    String fieldName = "asdf";
+    String keyString = serialize(classRef, false) + "_" + objNb + "_" + fieldName;
+    DocFormRequestKey key = parser.parse(keyString, docRef);
+    assertKey(key, keyString, docRef, classRef, false, objNb, fieldName);
+  }
+
+  @Test
+  public void testParse_obj_local() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    Integer objNb = 3;
+    String fieldName = "asdf";
+    String keyString = serialize(docRef, true) + "_" + serialize(classRef, true) + "_" 
+        + objNb + "_" + fieldName;
+    DocFormRequestKey key = parser.parse(keyString, null);
+    docRef.setWikiReference(new WikiReference("xwikidb"));
+    classRef.setWikiReference(new WikiReference("xwikidb"));
+    assertKey(key, keyString, docRef, classRef, false, objNb, fieldName);
+  }
+
+  @Test
+  public void testParse_obj_longFieldName() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    Integer objNb = 3;
+    String fieldName = "asdf_asdf2";
+    String keyString = serialize(classRef, false) + "_" + objNb + "_" + fieldName;
+    DocFormRequestKey key = parser.parse(keyString, docRef);
+    assertKey(key, keyString, docRef, classRef, false, objNb, fieldName);
+  }
+
+  @Test
+  public void testParse_obj_create() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    Integer objNb = -3;
+    String fieldName = "asdf";
+    String keyString = serialize(classRef, false) + "_" + objNb + "_" + fieldName;
+    DocFormRequestKey key = parser.parse(keyString, docRef);
+    assertKey(key, keyString, docRef, classRef, false, objNb, fieldName);
+  }
+
+  @Test
+  public void testParse_obj_delete() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    Integer objNb = 3;
+    String fieldName = "asdf";
+    String keyString = serialize(classRef, false) + "_^" + objNb + "_" + fieldName;
+    DocFormRequestKey key = parser.parse(keyString, docRef);
+    assertKey(key, keyString, docRef, classRef, true, objNb, fieldName);
+  }
+
+  @Test
+  public void testParse_obj_delete_noFieldName() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    Integer objNb = 3;
+    String keyString = serialize(classRef, false) + "_^" + objNb + "_";
+    DocFormRequestKey key = parser.parse(keyString, docRef);
+    assertKey(key, keyString, docRef, classRef, true, objNb, "");
+  }
+
+  @Test
+  public void testParse_obj_delete_negative() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    Integer objNb = -3;
+    String keyString = serialize(classRef, false) + "_^" + objNb;
+    try {
+      parser.parse(keyString, docRef);
+      fail("expecting IllegalArgumentException, delete and create not allowed together");
+    } catch (IllegalArgumentException iae) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testParse_obj_invalid_fullName() {
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    Integer objNb = 3;
+    String fieldName = "asdf";
+    String keyString = "Wiki:SpaceDoc_" + serialize(classRef, false) + "_" + objNb + "_" 
+        + fieldName;
+    try {
+      parser.parse(keyString, null);
+      fail("expecting IllegalArgumentException, invalid fullName");
+    } catch (IllegalArgumentException iae) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testParse_obj_invalid_className() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    Integer objNb = 3;
+    String fieldName = "asdf";
+    String keyString = serialize(docRef, false) + "_Wiki:ClassesClass_"  + objNb + "_" 
+        + fieldName;
+    try {
+      parser.parse(keyString, docRef);
+      fail("expecting IllegalArgumentException, invalid fullName");
+    } catch (IllegalArgumentException iae) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testParse_obj_invalid_objNb() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    String fieldName = "asdf";
+    String keyString = serialize(docRef, false) + "_" + serialize(classRef, false) 
+        + "_3a_" + fieldName;
+    try {
+      parser.parse(keyString, docRef);
+      fail("expecting IllegalArgumentException, invalid fullName");
+    } catch (IllegalArgumentException iae) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testParse_obj_invalid_fieldName() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    Integer objNb = 3;
+    String keyString = serialize(docRef, false) + "_" + serialize(classRef, false) + "_" 
+        + objNb + "_";
+    try {
+      parser.parse(keyString, docRef);
+      fail("expecting IllegalArgumentException, invalid fullName");
+    } catch (IllegalArgumentException iae) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testParse_multiple() {
+    DocumentReference docRef = new DocumentReference("Wiki", "Space", "Doc");    
+    DocumentReference classRef = new DocumentReference("Wiki", "Classes", "Class");
+    Integer objNb1 = 3;
+    String keyString = serialize(classRef, false) + "_^" + objNb1;
+    String keyString1 = serialize(classRef, false) + "_" + objNb1 + "_asdf1";
+    String keyString2 = serialize(classRef, false) + "_" + objNb1 + "_asdf2";
+    String keyString3 = serialize(classRef, false) + "_" + objNb1 + "_asdf3";
+    String keyStringContent = "content";
+    DocumentReference classRef2 = new DocumentReference("Wiki", "Classes", "OtherClass");
+    Integer objNb2 = 5;
+    String fieldName2 = "asdf";
+    String keyStringOther = serialize(classRef2, false) + "_" + objNb2 + "_" + fieldName2;
+    
+    Collection<DocFormRequestKey> keys = parser.parse(Arrays.asList(keyString1, 
+        keyString2, keyString, keyString3, keyStringContent, keyStringOther), docRef);
+    
+    assertEquals(3, keys.size());
+    Iterator<DocFormRequestKey> iter = keys.iterator();
+    assertKey(iter.next(), keyString, docRef, classRef, true, objNb1, "");
+    assertKey(iter.next(), keyStringContent, docRef, null, false, null, keyStringContent);
+    assertKey(iter.next(), keyStringOther, docRef, classRef2, false, objNb2, fieldName2);
+  }
+
+  private void assertKey(DocFormRequestKey key, String keyString, DocumentReference docRef,
+      DocumentReference classRef, boolean remove, Integer objNb, String  fieldName) {
+    assertEquals(keyString, key.getKeyString());
+    assertEquals(docRef, key.getDocRef());
+    assertEquals(classRef, key.getClassRef());
+    assertSame(remove, key.isRemove());
+    assertEquals(objNb, key.getObjNb());
+    assertEquals(fieldName, key.getFieldName());
+  }
+
+  private String serialize(DocumentReference docRef, boolean local) {
+    EntityReferenceSerializer<String> serializer;
+    if (local) {
+      serializer = Utils.getComponent(IWebUtilsService.class).getRefLocalSerializer();
+    } else {
+      serializer = Utils.getComponent(IWebUtilsService.class).getRefDefaultSerializer();
+    }
+    return serializer.serialize(docRef);
+  }
+  
+}

--- a/src/test/java/com/celements/web/plugin/cmd/DocFormCommandTest.java
+++ b/src/test/java/com/celements/web/plugin/cmd/DocFormCommandTest.java
@@ -34,6 +34,8 @@ import org.junit.Test;
 import org.xwiki.model.reference.DocumentReference;
 
 import com.celements.common.test.AbstractBridgedComponentTestCase;
+import com.celements.docform.DocFormRequestKey;
+import com.celements.docform.DocFormRequestKeyParser;
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -55,45 +57,8 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
   @Before
   public void setUp_DocFormCommandTest() throws Exception {
     context = getContext();
-    xwiki = createMock(XWiki.class);
-    context.setWiki(xwiki);
+    xwiki = getWikiMock();
     docFormCmd = new DocFormCommand();
-  }
-
-  @Test
-  public void testGetDocFullname_getDefault() {
-    assertArrayEquals(new String[]{"Full", "Name", "Oh.Noes_0_blabla"},
-        docFormCmd.getDocFullname("Oh.Noes_0_blabla", "Full", "Name"));
-  }
-  
-  @Test
-  public void testGetDocFullname_title() {
-    assertArrayEquals(new String[]{"Oh", "Noes", "title"}, 
-        docFormCmd.getDocFullname("Oh.Noes_title", "Full", "Name"));
-  }
-  
-  @Test
-  public void testGetDocFullname_defaultDocContent() {
-    assertArrayEquals(new String[]{"Full", "Name", "content"}, 
-        docFormCmd.getDocFullname("content", "Full", "Name"));
-  }
-  
-  @Test
-  public void testGetDocFullname_content() {
-    assertArrayEquals(new String[]{"Oh", "Noes", "content"}, 
-        docFormCmd.getDocFullname("Oh.Noes_content", "Full", "Name"));
-  }
-  
-  @Test
-  public void testGetDocFullname_objField() {
-    assertArrayEquals(new String[]{"Oh", "Noes", "A.B_52_bla_40bla"}, 
-        docFormCmd.getDocFullname("Oh.Noes_A.B_52_bla_40bla", "Full", "Name"));
-  }
-  
-  @Test
-  public void testGetDocFullname_objFieldWithDoc() {
-    assertArrayEquals(new String[]{"Full", "Name", "Oh.Noes_52_bla_40bla"},
-        docFormCmd.getDocFullname("Oh.Noes_52_bla_40bla", "Full", "Name"));
   }
 
   @Test
@@ -122,67 +87,123 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
       "Name");
     XWikiDocument doc = new XWikiDocument(docRef);
     expect(xwiki.getDocument(eq(docRef), same(context))).andReturn(doc).atLeastOnce();
-    replayAll();
+    replayDefault();
     XWikiDocument updateDoc = docFormCmd.getUpdateDoc(docRef, context);
     assertNotNull(updateDoc);
     assertEquals(doc, updateDoc);
-    verifyAll();
+    verifyDefault();
   }
   
   @Test
-  public void setObjValue_fillMap() throws XWikiException {
-    DocumentReference docRef = new DocumentReference(context.getDatabase(),
-        "Sp", "Doc");
-    XWikiDocument doc = new XWikiDocument(docRef);
-    BaseObject obj = createMock(BaseObject.class);
-    obj.setDocumentReference(eq(docRef));
-    expectLastCall().atLeastOnce();
-    obj.setNumber(eq(0));
+  public void setOrRemoveObj_fromCache() throws XWikiException {
+    DocumentReference docRef = new DocumentReference("W", "Sp", "Doc");
+    XWikiDocument docMock = createMockAndAddToDefault(XWikiDocument.class);
+    DocFormRequestKey key = new DocFormRequestKeyParser().parse("A.B_0_hi", docRef);
+    String value = "value";
+    BaseObject objMock = createMockAndAddToDefault(BaseObject.class);
+    docFormCmd.getChangedObjects().put("W:Sp.Doc_W:A.B_0", objMock);
+    objMock.set(eq("hi"), eq(value), same(context));
     expectLastCall().once();
-    expect(obj.getNumber()).andReturn(0).atLeastOnce();
-    expect(obj.getXClassReference()).andReturn(new DocumentReference(
-        context.getDatabase(), "A", "B")).atLeastOnce();
-    obj.set(eq("hi"), eq("value"), same(context));
+    replayDefault();
+    docFormCmd.setOrRemoveObj(docMock, key, value, context);
+    verifyDefault();
+  }
+  
+  @Test
+  public void setOrRemoveObj_get() throws XWikiException {
+    DocumentReference docRef = new DocumentReference("W", "Sp", "Doc");
+    XWikiDocument docMock = createMockAndAddToDefault(XWikiDocument.class);
+    DocFormRequestKey key = new DocFormRequestKeyParser().parse("A.B_0_hi", docRef);
+    DocumentReference classRef = new DocumentReference("W", "A", "B");
+    BaseObject objMock = createMockAndAddToDefault(BaseObject.class);
+    expect(docMock.getXObject(eq(classRef), eq(0))).andReturn(objMock).once();
+    String value = "value";
+    objMock.set(eq("hi"), eq(value), same(context));
     expectLastCall().once();
-    replay(obj);
-    doc.addXObject(obj);
-    replayAll();
-    String key = "A.B_0_hi";
-    String[] value = new String[]{ "value" };
-    docFormCmd.setObjValue(doc, key, value, context);
-    assertEquals(obj, docFormCmd.getChangedObjects().get("Sp.Doc_A.B_0"));
-    verifyAll(obj);
+    
+    replayDefault();
+    docFormCmd.setOrRemoveObj(docMock, key, value, context);
+    verifyDefault();
+    
+    assertEquals(objMock, docFormCmd.getChangedObjects().get("W:Sp.Doc_W:A.B_0"));
+  }
+  
+  // TODO do nothing in this case?
+  @Test
+  public void setOrRemoveObj_get_notExists() throws XWikiException {
+    DocumentReference docRef = new DocumentReference("W", "Sp", "Doc");
+    XWikiDocument docMock = createMockAndAddToDefault(XWikiDocument.class);
+    DocFormRequestKey key = new DocFormRequestKeyParser().parse("A.B_0_hi", docRef);
+    DocumentReference classRef = new DocumentReference("W", "A", "B");
+    expect(docMock.getXObject(eq(classRef), eq(0))).andReturn(null).once();
+    String value = "value";
+    
+    replayDefault();
+    docFormCmd.setOrRemoveObj(docMock, key, value, context);
+    verifyDefault();
+    
+    assertNull(docFormCmd.getChangedObjects().get("W:Sp.Doc_W:A.B_0"));
   }
   
   @Test
-  public void setObjValue_one_object() throws XWikiException {
-    DocumentReference docRef = new DocumentReference(context.getDatabase(), "Sp", "Doc");
-    XWikiDocument doc = new XWikiDocument(docRef);
-    String key = "A.B_0_hi";
-    String[] value = new String[]{ "value" };
-    BaseObject obj = createMock(BaseObject.class);
-    docFormCmd.getChangedObjects().put("Sp.Doc_A.B_0", obj);
-    obj.set(eq("hi"), eq(value[0]), same(context));
+  public void setOrRemoveObj_create() throws XWikiException {
+    DocumentReference docRef = new DocumentReference("W", "Sp", "Doc");
+    XWikiDocument docMock = createMockAndAddToDefault(XWikiDocument.class);
+    DocFormRequestKey key1 = new DocFormRequestKeyParser().parse("A.B_-1_hi", docRef);
+    DocumentReference classRef1 = new DocumentReference("W", "A", "B");
+    BaseObject objMock1 = createMockAndAddToDefault(BaseObject.class);
+    expect(docMock.getXObject(eq(classRef1), eq(-1))).andReturn(null).once();
+    expect(docMock.newXObject(eq(classRef1), same(context))).andReturn(objMock1).once();
+    String value1 = "value1";
+    objMock1.set(eq("hi"), eq(value1), same(context));
     expectLastCall();
-    replayAll(obj);
-    docFormCmd.setObjValue(doc, key, value, context);
-    verifyAll(obj);
+    DocFormRequestKey key2 = new DocFormRequestKeyParser().parse("B.C_0_bla", docRef);
+    String value2 = "value2";
+    BaseObject objMock2 = createMockAndAddToDefault(BaseObject.class);
+    docFormCmd.getChangedObjects().put("W:Sp.Doc_W:B.C_0", objMock2);
+    objMock2.set(eq("bla"), eq(value2), same(context));
+    expectLastCall();
+    
+    replayDefault();
+    docFormCmd.setOrRemoveObj(docMock, key1, value1, context);
+    docFormCmd.setOrRemoveObj(docMock, key2, value2, context);
+    verifyDefault();
+    
+    assertEquals(objMock1, docFormCmd.getChangedObjects().get("W:Sp.Doc_W:A.B_-1"));
+    assertEquals(objMock2, docFormCmd.getChangedObjects().get("W:Sp.Doc_W:B.C_0"));
   }
   
   @Test
-  public void setObjValue_two_objects() throws XWikiException {
-    DocumentReference docRef = new DocumentReference(context.getDatabase(), "Sp", "Doc");
-    XWikiDocument doc = new XWikiDocument(docRef);
-    String key = "B.C_0_bla";
-    String[] value = new String[]{ "value" };
-    BaseObject obj = createMock(BaseObject.class);
-    docFormCmd.getChangedObjects().put("Sp.Doc_A.B_0", null);
-    docFormCmd.getChangedObjects().put("Sp.Doc_B.C_0", obj);
-    obj.set(eq("bla"), eq(value[0]), same(context));
-    expectLastCall();
-    replayAll(obj);
-    docFormCmd.setObjValue(doc, key, value, context);
-    verifyAll(obj);
+  public void setOrRemoveObj_remove_fromCache() throws XWikiException {
+    DocumentReference docRef = new DocumentReference("W", "Sp", "Doc");
+    XWikiDocument docMock = createMockAndAddToDefault(XWikiDocument.class);
+    DocFormRequestKey key = new DocFormRequestKeyParser().parse("A.B_^0", docRef);
+    BaseObject objMock = createMockAndAddToDefault(BaseObject.class);
+    docFormCmd.getChangedObjects().put("W:Sp.Doc_W:A.B_0", objMock);
+    expect(docMock.removeXObject(same(objMock))).andReturn(true).once();
+    
+    replayDefault();
+    docFormCmd.setOrRemoveObj(docMock, key, "", context);
+    verifyDefault();
+    
+    assertEquals(objMock, docFormCmd.getChangedObjects().get("W:Sp.Doc_W:A.B_0"));
+  }
+  
+  @Test
+  public void setOrRemoveObj_remove() throws XWikiException {
+    DocumentReference docRef = new DocumentReference("W", "Sp", "Doc");
+    XWikiDocument docMock = createMockAndAddToDefault(XWikiDocument.class);
+    DocFormRequestKey key = new DocFormRequestKeyParser().parse("A.B_^0", docRef);
+    DocumentReference classRef = new DocumentReference("W", "A", "B");
+    BaseObject objMock = createMockAndAddToDefault(BaseObject.class);
+    expect(docMock.getXObject(eq(classRef), eq(0))).andReturn(objMock).once();
+    expect(docMock.removeXObject(same(objMock))).andReturn(true).once();
+    
+    replayDefault();
+    docFormCmd.setOrRemoveObj(docMock, key, "", context);
+    verifyDefault();
+    
+    assertEquals(objMock, docFormCmd.getChangedObjects().get("W:Sp.Doc_W:A.B_0"));
   }
 
   @Test
@@ -206,13 +227,13 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
     doc.setXClass(bclass);
     expect(xwiki.getDocument(eq(bclassDocRef), same(context))).andReturn(doc
         ).atLeastOnce();
-    replayAll();
+    replayDefault();
     String result = docFormCmd.validateField("Test.TestClass", "testField", "value",
         context);
     assertNull("Successful validation should result in answoer null", result);
     result = docFormCmd.validateField("Test.TestClass", "testField", "", context);
     assertEquals("msg", result);
-    verifyAll();
+    verifyDefault();
   }
   
   @Test
@@ -229,6 +250,8 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
     assertFalse("".matches(docFormCmd.getFindObjectFieldInRequestRegex()));
     assertFalse("abcd".matches(docFormCmd.getFindObjectFieldInRequestRegex()));
     assertFalse("Hi_0_there".matches(docFormCmd.getFindObjectFieldInRequestRegex()));
+    assertFalse("Space.Doc_Class.Name_+3_field".matches(
+        docFormCmd.getFindObjectFieldInRequestRegex()));
   }
   
   @Test
@@ -236,6 +259,10 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
     assertTrue("Space.Doc_0_field_one".matches(
         docFormCmd.getFindObjectFieldInRequestRegex()));
     assertTrue("Space.Doc_Class.Name_3_field".matches(
+        docFormCmd.getFindObjectFieldInRequestRegex()));
+    assertTrue("Space.Doc_Class.Name_-3_field".matches(
+        docFormCmd.getFindObjectFieldInRequestRegex()));
+    assertTrue("Space.Doc_Class.Name_^3_field".matches(
         docFormCmd.getFindObjectFieldInRequestRegex()));
   }
   
@@ -259,7 +286,6 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
     BaseObject obj = createMock(BaseObject.class);
     obj.setNumber(1);
     expectLastCall().once();
-    expect(obj.getNumber()).andReturn(1).atLeastOnce();
     obj.set(eq("blabla2"), eq("Another Blabla Value"), same(context));
     expectLastCall();
     DocumentReference fullNameRef = new DocumentReference(context.getDatabase(), "Full",
@@ -269,7 +295,6 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
     BaseObject obj2 = createMock(BaseObject.class);
     obj2.setNumber(0);
     expectLastCall().once();
-    expect(obj2.getNumber()).andReturn(0).atLeastOnce();
     obj2.set(eq("blabla"), eq("Blabla Value"), same(context));
     expectLastCall().once();
     DocumentReference specificDocRef = new DocumentReference(context.getDatabase(), "Oh",
@@ -293,13 +318,13 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
       "Noes");
     expect(xwiki.getDocument(eq(doc2Ref), same(context))).andReturn(specificDoc
         ).once();
-    XWikiRequest request = createMock(XWikiRequest.class);
+    XWikiRequest request = createMockAndAddToDefault(XWikiRequest.class);
     context.setRequest(request);
     expect(request.getParameter(eq("template"))).andReturn("");
-    replayAll(request);
+    replayDefault();
     Set<XWikiDocument> changedDocs = docFormCmd.updateDocFromMap("Full.Name", 
         data, context);
-    verifyAll(obj, obj2, request);
+    verifyDefault(obj, obj2);
     assertTrue(changedDocs.contains(defaultDoc));
     assertEquals(2, defaultDoc.getXObjects(cdClassRef).size());
     assertTrue(changedDocs.contains(specificDoc));
@@ -325,23 +350,23 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
       "Noes");
     expect(xwiki.getDocument(eq(doc2Ref), same(context))).andReturn(specificDoc
         ).once();
-    XWikiRequest request = createMock(XWikiRequest.class);
+    XWikiRequest request = createMockAndAddToDefault(XWikiRequest.class);
     context.setRequest(request);
     expect(request.getParameter(eq("template"))).andReturn("Templates.MyTempl");
     DocumentReference templRef = new DocumentReference(context.getDatabase(), "Templates",
         "MyTempl");
     XWikiDocument templDoc = new XWikiDocument(templRef);
     expect(xwiki.getDocument(eq(templRef), same(context))).andReturn(templDoc);
-    XWikiStoreInterface store = createMock(XWikiStoreInterface.class);
+    XWikiStoreInterface store = createMockAndAddToDefault(XWikiStoreInterface.class);
 //    //TODO is there a better method to match the parameter? -> eq and same do not work
 //    //     since loadXWikiDoc create a new XWikiDocument
 //    expect(store.loadXWikiDoc(isA(XWikiDocument.class), same(context))).andReturn(defaultDoc);
 //    expect(store.loadXWikiDoc(isA(XWikiDocument.class), same(context))).andReturn(specificDoc);
     expect(xwiki.getStore()).andReturn(store).anyTimes();
-    replayAll(store, request);
+    replayDefault();
     Set<XWikiDocument> changedDocs = docFormCmd.updateDocFromMap("Full.Name", data,
         context);
-    verifyAll(store, request);
+    verifyDefault();
     //TODO Check how it works - getTranslatedDoc seems to create a new object which leads
     //     to getContent() and getTitle() to be empty -> does it work correctly anyways?
     assertTrue(changedDocs.contains(defaultDoc));
@@ -358,7 +383,6 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
     BaseObject obj = createMock(BaseObject.class);
     obj.setNumber(1);
     expectLastCall().once();
-    expect(obj.getNumber()).andReturn(1).atLeastOnce();
     obj.set(eq("blabla2"), eq("Another Blabla Value"), same(context));
     expectLastCall();
     DocumentReference fullNameRef = new DocumentReference(context.getDatabase(), "Full",
@@ -368,7 +392,6 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
     BaseObject obj2 = createMock(BaseObject.class);
     obj2.setNumber(0);
     expectLastCall().once();
-    expect(obj2.getNumber()).andReturn(0).atLeastOnce();
     obj2.set(eq("blabla"), eq("Blabla Value"), same(context));
     expectLastCall().once();
     DocumentReference specificDocRef = new DocumentReference(context.getDatabase(), "Oh",
@@ -394,31 +417,21 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
       "Noes");
     expect(xwiki.getDocument(eq(doc2Ref), same(context))).andReturn(specificDoc
         ).once();
-    XWikiRequest request = createMock(XWikiRequest.class);
+    XWikiRequest request = createMockAndAddToDefault(XWikiRequest.class);
     context.setRequest(request);
     expect(request.getParameter(eq("template"))).andReturn("Templates.MyTempl");
     DocumentReference templRef = new DocumentReference(context.getDatabase(), "Templates",
         "MyTempl");
     XWikiDocument templDoc = new XWikiDocument(templRef);
     expect(xwiki.getDocument(eq(templRef), same(context))).andReturn(templDoc);
-    replayAll(request);
+    replayDefault();
     Set<XWikiDocument> changedDocs = docFormCmd.updateDocFromMap("Full.Name", 
         data, context);
-    verifyAll(obj, obj2, request);
+    verifyDefault(obj, obj2);
     assertTrue(changedDocs.contains(defaultDoc));
     assertEquals(2, defaultDoc.getXObjects(cdClassRef).size());
     assertTrue(changedDocs.contains(specificDoc));
     assertEquals(1, specificDoc.getXObjects(abClassRef).size());
   }
 
-  
-  private void replayAll(Object ... mocks) {
-    replay(xwiki);
-    replay(mocks);
-  }
-
-  private void verifyAll(Object ... mocks) {
-    verify(xwiki);
-    verify(mocks);
-  }
 }

--- a/src/test/java/com/celements/web/plugin/cmd/DocFormCommandTest.java
+++ b/src/test/java/com/celements/web/plugin/cmd/DocFormCommandTest.java
@@ -128,7 +128,6 @@ public class DocFormCommandTest extends AbstractBridgedComponentTestCase {
     assertEquals(objMock, docFormCmd.getChangedObjects().get("W:Sp.Doc_W:A.B_0"));
   }
   
-  // TODO do nothing in this case?
   @Test
   public void setOrRemoveObj_get_notExists() throws XWikiException {
     DocumentReference docRef = new DocumentReference("W", "Sp", "Doc");


### PR DESCRIPTION
- added functionality to remove obj via DocFormCommand (with preceding "^" to objNb)
- refactored request key parsing for DocFormCommand to own parser with return class