### PR TITLE
fix creation of document reference before loading

### DIFF
--- a/src/main/java/com/celements/store/DocumentCacheStore.java
+++ b/src/main/java/com/celements/store/DocumentCacheStore.java
@@ -98,7 +98,7 @@ public class DocumentCacheStore implements XWikiCacheStoreInterface, MetaDataSto
   private CacheManager cacheManager;
 
   @Requirement
-  private ModelContext context;
+  private ModelContext modelContext;
 
   @Requirement
   private ModelUtils modelUtils;
@@ -161,7 +161,8 @@ public class DocumentCacheStore implements XWikiCacheStoreInterface, MetaDataSto
 
   private int getExistCacheCapacity() {
     int existCacheCapacity = 10000;
-    String existsCapacity = context.getXWikiContext().getWiki().Param(PARAM_EXIST_CACHE_CAPACITY);
+    String existsCapacity = modelContext.getXWikiContext().getWiki().Param(
+        PARAM_EXIST_CACHE_CAPACITY);
     if (existsCapacity != null) {
       try {
         existCacheCapacity = Integer.parseInt(existsCapacity);
@@ -191,7 +192,7 @@ public class DocumentCacheStore implements XWikiCacheStoreInterface, MetaDataSto
 
   private int getDocCacheCapacity() {
     int docCacheCapacity = 100;
-    String capacity = context.getXWikiContext().getWiki().Param(PARAM_DOC_CACHE_CAPACITY);
+    String capacity = modelContext.getXWikiContext().getWiki().Param(PARAM_DOC_CACHE_CAPACITY);
     if (capacity != null) {
       try {
         docCacheCapacity = Integer.parseInt(capacity);
@@ -267,7 +268,7 @@ public class DocumentCacheStore implements XWikiCacheStoreInterface, MetaDataSto
 
   String getKey(DocumentReference docRef) {
     DocumentReference cacheDocRef = References.adjustRef(docRef, DocumentReference.class,
-        context.getWikiRef());
+        modelContext.getWikiRef());
     return modelUtils.serializeRef(cacheDocRef);
   }
 
@@ -367,7 +368,8 @@ public class DocumentCacheStore implements XWikiCacheStoreInterface, MetaDataSto
   @Override
   public XWikiDocument loadXWikiDoc(XWikiDocument doc, XWikiContext context) throws XWikiException {
     LOGGER.trace("Cache: begin for docRef '{}' in cache", doc.getDocumentReference());
-    String key = getKey(doc.getDocumentReference());
+    DocumentReference contextDocRef = getDocRefContextDb(doc);
+    String key = getKey(contextDocRef);
     String keyWithLang = getKeyWithLang(doc);
     if (doesNotExistsForKey(key) || doesNotExistsForKey(keyWithLang)) {
       LOGGER.debug("Cache: The document {} does not exist, return an empty one", keyWithLang);
@@ -375,7 +377,7 @@ public class DocumentCacheStore implements XWikiCacheStoreInterface, MetaDataSto
       doc.setNew(true);
       // Make sure to always return a document with an original version, even for one that does
       // not exist. This allows to write more generic code.
-      doc.setOriginalDocument(new XWikiDocument(doc.getDocumentReference()));
+      doc.setOriginalDocument(new XWikiDocument(contextDocRef));
       return doc;
     } else {
       LOGGER.debug("Cache: Trying to get doc '{}' from cache", keyWithLang);
@@ -388,6 +390,11 @@ public class DocumentCacheStore implements XWikiCacheStoreInterface, MetaDataSto
       LOGGER.trace("Cache: end for doc '{}' in cache", keyWithLang);
       return cachedoc;
     }
+  }
+
+  private DocumentReference getDocRefContextDb(XWikiDocument doc) {
+    return References.adjustRef(doc.getDocumentReference(), DocumentReference.class,
+        modelContext.getWikiRef());
   }
 
   private boolean doesNotExistsForKey(String key) {
@@ -736,11 +743,7 @@ public class DocumentCacheStore implements XWikiCacheStoreInterface, MetaDataSto
 
   static enum InvalidateState {
 
-    CACHE_MISS,
-    REMOVED,
-    LOADING_CANCELED,
-    LOADING_MULTI_CANCELED,
-    LOADING_CANCEL_FAILED
+    CACHE_MISS, REMOVED, LOADING_CANCELED, LOADING_MULTI_CANCELED, LOADING_CANCEL_FAILED
 
   }
 
@@ -849,7 +852,7 @@ public class DocumentCacheStore implements XWikiCacheStoreInterface, MetaDataSto
         LOGGER_DL.trace("DocumentLoader-{}: Trying to get doc '{}' for real",
             Thread.currentThread().getId(), key);
         // IMPORTANT: do not clone here. Creating new document is much faster.
-        XWikiDocument buildDoc = new XWikiDocument(doc.getDocumentReference());
+        XWikiDocument buildDoc = new XWikiDocument(getDocRefContextDb(doc));
         buildDoc.setLanguage(doc.getLanguage());
         buildDoc = getBackingStore().loadXWikiDoc(buildDoc, context);
         buildDoc.setStore(getBackingStore());
@@ -902,7 +905,7 @@ public class DocumentCacheStore implements XWikiCacheStoreInterface, MetaDataSto
     String hql = sb.toString();
     Query query = getQueryManager().createQuery(hql, Query.HQL);
     query.setWiki(References.extractRef(filterRef, WikiReference.class).or(
-        context.getWikiRef()).getName());
+        modelContext.getWikiRef()).getName());
     for (Entry<String, String> bind : bindValues.entrySet()) {
       query.bindValue(bind.getKey(), bind.getValue());
     }


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-462

The WikiReference in the document reference set on the new document in the document builder has not been adjusted to the context database. Thus even though the document was loaded from the context database 'myWiki' the document reference might have had a wrong wiki reference.