### PR TITLE
correct NPE in getAppRecursiveSetupScript and add tests

### DIFF
--- a/src/main/java/com/celements/appScript/AppScriptService.java
+++ b/src/main/java/com/celements/appScript/AppScriptService.java
@@ -217,8 +217,8 @@ public class AppScriptService implements IAppScriptService {
     String scriptNameTest = scriptName;
     do {
       scriptNameTest = reduceOneDirectory(scriptNameTest);
-    } while (!hasFound.test(scriptNameTest) && hasMore.test(scriptNameTest));
-    if (hasFound.test(scriptNameTest)) {
+    } while (scriptNameTest != null && !hasFound.test(scriptNameTest) && hasMore.test(scriptNameTest));
+    if (scriptNameTest != null && hasFound.test(scriptNameTest)) {
       return Optional.of(scriptNameTest);
     }
     return Optional.empty();

--- a/src/test/java/com/celements/appScript/AppScriptServiceTest.java
+++ b/src/test/java/com/celements/appScript/AppScriptServiceTest.java
@@ -748,6 +748,34 @@ public class AppScriptServiceTest extends AbstractComponentTest {
     verifyDefault();
   }
 
+  @Test
+  public void test_getAppRecursiveScript_singleSegment() {
+    replayDefault();
+    assertFalse(appScriptService.getAppRecursiveScript("path").isPresent());
+    verifyDefault();
+  }
+
+  @Test
+  public void test_getAppRecursiveScript_null() {
+    replayDefault();
+    assertFalse(appScriptService.getAppRecursiveScript(null).isPresent());
+    verifyDefault();
+  }
+
+  @Test
+  public void test_getAppRecursiveScriptDocRef_singleSegment() {
+    replayDefault();
+    assertFalse(appScriptService.getAppRecursiveScriptDocRef("path").isPresent());
+    verifyDefault();
+  }
+
+  @Test
+  public void test_getAppRecursiveScriptDocRef_null() {
+    replayDefault();
+    assertFalse(appScriptService.getAppRecursiveScriptDocRef(null).isPresent());
+    verifyDefault();
+  }
+
   private DocumentReference createScriptDocRef(String scriptName) {
     return RefBuilder
         .from(new WikiReference(getXContext().getDatabase()))


### PR DESCRIPTION
## Description

Fixes a `NullPointerException` thrown in `AppScriptService` when resolving recursive scripts or recursive script document references for `null` or single-segment (e.g., no slashes) script names.

### Problem
When `getAppRecursiveScript` or `getAppRecursiveScriptDocRef` is called with a script name that doesn't contain a slash `/` (or is `null`), the internal directory reduction logic (`reduceOneDirectory`) returns `null`. This null reference was then passed directly to the `hasMore` predicate (`sn -> sn.lastIndexOf("/") > 0`), triggering a `NullPointerException`.

### Solution
- Updated the `findAppScriptRecursivly` helper method in `AppScriptService.java` to check for `null` in both the loop termination condition and the post-loop validation.
- This ensures that if the script name is reduced to `null`, the search terminates immediately and returns an empty `Optional` safely without invoking the predicates on `null`.

## Checklist / Testing
- [x] Added unit tests covering `null` and single-segment path parameters for both `getAppRecursiveScript` and `getAppRecursiveScriptDocRef` in `AppScriptServiceTest.java`.
- [x] Verified that all tests in `AppScriptServiceTest` pass.
- [x] Ran the entire `celements-core` unit test suite locally to verify no regressions.
